### PR TITLE
Made query optional the SED class constructor

### DIFF
--- a/sed/builder.py
+++ b/sed/builder.py
@@ -440,7 +440,7 @@ class SED(object):
     """
 
     def __init__(self, ID=None, photfile=None, plx=None, load_fits=True,
-                 load_hdf5=True, label=''):
+                 load_hdf5=True, label='', no_query=False):
         """
         Initialize SED class.
 
@@ -475,7 +475,7 @@ class SED(object):
         else:
             self.photfile = photfile
 
-        # -- load information from the photometry file if it exists
+        # -- Load information from the photometry file if it exists.
         if not os.path.isfile(self.photfile):
             try:
                 self.info = sesame.search(os.path.basename(ID),fix=True)
@@ -509,7 +509,7 @@ class SED(object):
             if self.ID is None:
                 self.ID = os.path.splitext(os.path.basename(self.photfile))[0]#self.info['oname']
                 logger.info('Name from file used to set ID of object')
-        # --load information from the FITS file if it exists
+        # -- Load information from the FITS and HDF5 files.
         self.results = {}
         self.constraints = {}
         if load_fits:

--- a/sed/builder.py
+++ b/sed/builder.py
@@ -440,7 +440,7 @@ class SED(object):
     """
 
     def __init__(self, ID=None, photfile=None, plx=None, load_fits=True,
-                 load_hdf5=True, label='', no_query=False):
+                 load_hdf5=True, label='', query=True):
         """
         Initialize SED class.
 
@@ -483,8 +483,11 @@ class SED(object):
             if self.ID is None:
                 self.ID = os.path.splitext(os.path.basename(self.photfile))[0]#self.info['oname']
                 logger.info('Name from file used to set ID of object')
-        # -- Photometry file does not exist.
-        else:
+        # -- The photometry file does not exist. Check if the object
+        #   name should be queried. This action seems to make little
+        #   sense, but perhaps it exists for the convenience of the
+        #   interactive user.
+        elif query:
             try:
                 self.info = sesame.search(os.path.basename(ID),fix=True)
             except KeyError:
@@ -504,12 +507,17 @@ class SED(object):
                     logger.info('Resolved position via CoRoT EXO catalog')
                 except:
                     logger.warning("Star %s not recognised by CoRoT"%(os.path.basename(ID)))
-
+            # -- Some weird, undocumented parallax trick.
             if plx is not None:
                 if not 'plx' in self.info:
                     self.info['plx'] = {}
                 self.info['plx']['v'] = plx[0]
                 self.info['plx']['e'] = plx[1]
+        # -- The object name was not queried. Inform the user.
+        else:
+            logger.info('Star %s not queried during init'
+                %(os.path.basename(ID)))
+
         # -- Load information from the FITS and HDF5 files.
         self.results = {}
         self.constraints = {}

--- a/sed/builder.py
+++ b/sed/builder.py
@@ -476,7 +476,15 @@ class SED(object):
             self.photfile = photfile
 
         # -- Load information from the photometry file if it exists.
-        if not os.path.isfile(self.photfile):
+        if os.path.isfile(self.photfile):
+            self.load_photometry()
+            logger.info('Photometry loaded from file')
+            # -- if no ID was given, set the official name as the ID.
+            if self.ID is None:
+                self.ID = os.path.splitext(os.path.basename(self.photfile))[0]#self.info['oname']
+                logger.info('Name from file used to set ID of object')
+        # -- Photometry file does not exist.
+        else:
             try:
                 self.info = sesame.search(os.path.basename(ID),fix=True)
             except KeyError:
@@ -502,13 +510,6 @@ class SED(object):
                     self.info['plx'] = {}
                 self.info['plx']['v'] = plx[0]
                 self.info['plx']['e'] = plx[1]
-        else:
-            self.load_photometry()
-            logger.info('Photometry loaded from file')
-            # -- if no ID was given, set the official name as the ID.
-            if self.ID is None:
-                self.ID = os.path.splitext(os.path.basename(self.photfile))[0]#self.info['oname']
-                logger.info('Name from file used to set ID of object')
         # -- Load information from the FITS and HDF5 files.
         self.results = {}
         self.constraints = {}


### PR DESCRIPTION
Modified the SED class to allow creation of an instance without querying the online databases. This is convenient when processing a large amount of SEDs in one go, as it makes the instance construction a few seconds faster.